### PR TITLE
Auth scaffold: register/login/me endpoints, JWT and password hashing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ fastapi
 uvicorn
 sqlmodel
 sqlalchemy
+passlib[bcrypt]
+python-jose[cryptography]
+python-multipart

--- a/src/app.py
+++ b/src/app.py
@@ -18,6 +18,7 @@ from sqlmodel import Session, select
 
 from .db import engine, init_db, get_session, seed_data
 from .models import Activity, User, Registration
+from .auth import router as auth_router
 
 
 app = FastAPI(title="Mergington High School API",
@@ -33,6 +34,9 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
 # Initialize the database and seed sample data
 init_db()
 seed_data()
+
+# include auth routes
+app.include_router(auth_router, prefix="/auth")
 
 
 @app.get("/")

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,0 +1,102 @@
+import os
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from pydantic import BaseModel
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlmodel import select
+
+from .db import get_session
+from .models import User
+
+
+SECRET_KEY = os.getenv("SECRET_KEY", "dev-secret-change-me")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/login")
+
+router = APIRouter()
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password: str) -> str:
+    return pwd_context.hash(password)
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.utcnow() + expires_delta
+    else:
+        expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme), session=Depends(get_session)) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        email: str = payload.get("sub")
+        if email is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = session.exec(select(User).where(User.email == email)).first()
+    if user is None:
+        raise credentials_exception
+    return user
+
+
+@router.post("/register", status_code=201, response_model=Token)
+def register(form_data: OAuth2PasswordRequestForm = Depends(), session=Depends(get_session)):
+    """Register a new user. Uses form fields `username` and `password` from OAuth2 form spec."""
+    email = form_data.username
+    password = form_data.password
+
+    existing = session.exec(select(User).where(User.email == email)).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="User already exists")
+
+    user = User(email=email, hashed_password=get_password_hash(password))
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+
+    access_token = create_access_token(data={"sub": user.email})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.post("/login", response_model=Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), session=Depends(get_session)):
+    user = session.exec(select(User).where(User.email == form_data.username)).first()
+    if not user or not user.hashed_password:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    if not verify_password(form_data.password, user.hashed_password):
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+
+    access_token = create_access_token(data={"sub": user.email})
+    return {"access_token": access_token, "token_type": "bearer"}
+
+
+@router.get("/me")
+def read_users_me(current_user: User = Depends(get_current_user)):
+    return {"email": current_user.email, "name": current_user.name, "role": current_user.role}

--- a/src/models.py
+++ b/src/models.py
@@ -7,6 +7,8 @@ class User(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     email: str = Field(index=True, nullable=False)
     name: Optional[str] = None
+    hashed_password: Optional[str] = None
+    role: str = Field(default="student")
 
     registrations: List["Registration"] = Relationship(back_populates="user")
 


### PR DESCRIPTION
This PR scaffolds authentication endpoints and minimal infrastructure to protect actions.

What's included:
- `src/auth.py` — register/login/me endpoints using OAuth2 form, JWT tokens, and password hashing (bcrypt via passlib)
- `src/models.py` — added `hashed_password` and `role` fields to `User` model
- `src/app.py` — registers auth routes at `/auth`
- `requirements.txt` — added `passlib`, `python-jose`, and `python-multipart`

Notes:
- This is an initial scaffold. Next steps: enforce role checks on register/unregister, add tests, and consider migrations (Alembic) for schema evolution.